### PR TITLE
Restart policy changed to "unless-stopped"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     dns: 172.33.1.2
     privileged: true
-    restart: always
+    restart: unless-stopped
     networks:
       network:
         ipv4_address: 172.33.1.10


### PR DESCRIPTION
**Changes:** 

1. Changed restart policy from "always" to "unless-stopped"

**Why?**

For security reasons, the wifi container must be persistant with its status (running/stopped) so if a user stop the wifi it will keep that status after host machine restarts (docker daemon restarts).

According the [docs](https://docs.docker.com/config/containers/start-containers-automatically/) the best option is to change the restart policy to "unless-stopped" .

I have checked the status for the wifi container and a random package with restart policy "unless-stopped", and they remained their states after the reboot.

![Screenshot from 2020-12-01 13-17-35](https://user-images.githubusercontent.com/41727368/100752918-7481eb00-33e9-11eb-892a-fcae86522794.png)
