### PR TITLE
compose migration from 3.4 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 networks:
   dncore_network:
     name: dncore_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
 version: "3.4"
 networks:
-  network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.33.0.0/16
+  dncore_network:
+    name: dncore_network
+    external: true
 services:
   wifi.dnp.dappnode.eth:
     build: ./build
@@ -24,7 +22,9 @@ services:
     privileged: true
     restart: on-failure
     networks:
-      network:
+      dncore_network:
         ipv4_address: 172.33.1.10
+        aliases:
+          - wifi.dappnode
     logging:
       driver: journald


### PR DESCRIPTION
- Set `dncore_network` as external (will be asumme as created. The installer should create at installation https://github.com/dappnode/DAppNode_Installer/pull/98)
- Add alias

More info in https://github.com/dappnode/DNP_DAPPMANAGER/issues/655