### PR TITLE
Improved wifi availability

### DIFF
--- a/build/wlanstart.sh
+++ b/build/wlanstart.sh
@@ -50,7 +50,8 @@ if [ ${IFACE_OPSTATE::-1} = "down" ]; then
   INTERFACE=wlan0
 else
   echo "[Warning] Interface ${INTERFACE} already connected. WIFI hotspot cannot be initialized since the host machine is using it"
-  exit 0
+  sleep 10
+  exit 1
 fi
 
 if [ ! -f "/etc/hostapd.conf" ]; then

--- a/build/wlanstart.sh
+++ b/build/wlanstart.sh
@@ -23,6 +23,10 @@ CONTAINER_PID=$(docker inspect -f '{{.State.Pid}}' ${HOSTNAME})
 CONTAINER_IMAGE=$(docker inspect -f '{{.Config.Image}}' ${HOSTNAME})
 if [ -z ${INTERFACE} ]; then
   INTERFACE=$(docker run -t --privileged --net=host --pid=host --rm --entrypoint /bin/sh ${CONTAINER_IMAGE} -c "iw dev" | grep 'Interface' | awk 'NR==1{print $2}')
+  # Additional method to get network interface
+  if [ -z ${INTERFACE} ]; then
+    INTERFACE=$(docker run -t --privileged --net=host --pid=host --rm --entrypoint /bin/sh ${CONTAINER_IMAGE} -c "ls /sys/class/ieee80211/*/device/net")
+  fi
 fi
 
 # We have seen cases in which after an update it is not able to obtain the interface

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     dns: 172.33.1.2
     privileged: true
-    restart: on-failure
+    restart: unless-stopped
     networks:
       dncore_network:
         ipv4_address: 172.33.1.10


### PR DESCRIPTION
- Added aditional check to detect network interface
- Changed restart policy to `unless-stopped`
- Changed exit code from 0 to 1 when network interface is in use by the host

This will make wifi package to restart always, except in the following situations:
- User manually stop the package from the UI: this will make the container to exit with exit code 0.
- Network interface not found. Apparently, this check does not fail. Will prevent the container to restart on remote machines that does not have network interface